### PR TITLE
Pass make options to makefiles in subdirectories

### DIFF
--- a/makefile
+++ b/makefile
@@ -1,9 +1,9 @@
 DIRS = src shader
 INSTALL_DIRS = src shader config
 compile:
-	for i in $(DIRS); do make -C $$i; done
+	for i in $(DIRS); do $(MAKE) -C $$i; done
 	
 install:
-	for i in $(INSTALL_DIRS); do make install -C $$i; done
+	for i in $(INSTALL_DIRS); do $(MAKE) install -C $$i; done
 	
 	


### PR DESCRIPTION
Without this patch, sub-makefiles aren't building targets in parallel.

Please merge. Thanks.