### PR TITLE
Remove optimization level

### DIFF
--- a/README.md
+++ b/README.md
@@ -12,7 +12,7 @@ You need the vulkan sdk to build this and glslangValidator to compile the shader
 For Arch Linux and Manjaro Linux, they can be installed with:
 
 ```
-pacman -Sy glslang lib32-glslang vulkan-headers vulkan-tools vulkan-validation-layers
+pacman -Sy glslang vulkan-headers vulkan-tools vulkan-validation-layers
 ```
 
 Simply use

--- a/src/makefile
+++ b/src/makefile
@@ -1,5 +1,5 @@
 CPPC := g++
-CFLAGS := -O3 -fPIC #-Wall -Wextra
+CFLAGS := -fPIC #-Wall -Wextra
 LINKER :=  -shared -fvisibility=hidden
 
 BUILD_DIR := ../build


### PR DESCRIPTION
For whatever reason, setting optimization levels either causes freezing, O2 &
O3, or segfaults, O1 & Os.  Removing the optimization level also fixes issues
with AMD RX 580s from issue #3.

[Ticket: #8]