### PR TITLE
Remove optimization level

### DIFF
--- a/src/makefile
+++ b/src/makefile
@@ -1,5 +1,5 @@
 CPPC := g++
-CFLAGS := -O3 -fPIC #-Wall -Wextra
+CFLAGS := -fPIC #-Wall -Wextra
 LINKER :=  -shared -fvisibility=hidden
 
 BUILD_DIR := ../build


### PR DESCRIPTION
For whatever reason, setting optimization levels either causes freezing, O2 &
O3, or segfaults, O1 & Os.  Removing the optimization level also fixes issues
with AMD RX 580s from issue #3.

[Ticket: #8]