### PR TITLE
Remove lib32-glslang

### DIFF
--- a/README.md
+++ b/README.md
@@ -12,7 +12,7 @@ You need the vulkan sdk to build this and glslangValidator to compile the shader
 For Arch Linux and Manjaro Linux, they can be installed with:
 
 ```
-pacman -Sy glslang lib32-glslang vulkan-headers vulkan-tools vulkan-validation-layers
+pacman -Sy glslang vulkan-headers vulkan-tools vulkan-validation-layers
 ```
 
 Simply use


### PR DESCRIPTION
Since it's unnecessary to build vkBasalt as well as it's only in the AUR so it
wouldn't work with the pacman command.

[Ticket: #7]