### PR TITLE
Fix semaphore handling

### DIFF
--- a/src/command_buffer.cpp
+++ b/src/command_buffer.cpp
@@ -116,4 +116,16 @@ namespace vkBasalt
         }
     }
 
+
+    void createSemaphores(const VkDevice& device, const VkLayerDispatchTable& dispatchTable, uint32_t count, VkSemaphore* semaphores)
+    {
+        VkSemaphoreCreateInfo info;
+        info.sType = VK_STRUCTURE_TYPE_SEMAPHORE_CREATE_INFO;
+        info.pNext = nullptr;
+        info.flags = 0;
+
+        for (uint32_t i = 0; i < count; i++)
+            dispatchTable.CreateSemaphore(device, &info, nullptr, &semaphores[i]);
+    }
+
 }

--- a/src/command_buffer.hpp
+++ b/src/command_buffer.hpp
@@ -13,6 +13,7 @@ namespace vkBasalt
 {
     void allocateCommandBuffer(const VkDevice& device, const VkLayerDispatchTable& dispatchTable, const VkCommandPool& commandPool, const uint32_t& count, VkCommandBuffer* commandBuffers);
     void writeCASCommandBuffers(const VkDevice& device, const VkLayerDispatchTable& dispatchTable, const VkPipeline* pipelines, const VkPipelineLayout* layouts, const VkExtent2D& extent, const uint32_t& count,const VkImage* images, const VkDescriptorSet* descriptorSets, VkCommandBuffer* commandBuffers);
+    void createSemaphores(const VkDevice& device, const VkLayerDispatchTable& dispatchTable, uint32_t count, VkSemaphore* semaphores);
 }
 
 #endif // COMMAND_BUFFER_HPP_INCLUDED


### PR DESCRIPTION
Forward the wait semaphores to the **first** command buffer only, then insert a separate set of semaphores between the command buffer submission and the actual presentation.

The current approach works for games that present from the graphics queue, but id Tech 6 presents from compute, and we don't want the present to get scheduled before the command buffer submission.

Ideally we'd run the command buffer on the same queue as the present, but that is a lot trickier to fix.