### PR TITLE
Disable unused parameter warnings

### DIFF
--- a/src/command_buffer.cpp
+++ b/src/command_buffer.cpp
@@ -4,7 +4,7 @@
 #define ASSERT_VULKAN(val)\
         if(val!=VK_SUCCESS)\
         {\
-            throw std::runtime_error("ASSERT_VULKAN failed " + val);\
+            throw std::runtime_error("ASSERT_VULKAN failed " + std::to_string(val));\
         }
 #endif
 

--- a/src/compute_pipeline.cpp
+++ b/src/compute_pipeline.cpp
@@ -4,7 +4,7 @@
 #define ASSERT_VULKAN(val)\
         if(val!=VK_SUCCESS)\
         {\
-            throw std::runtime_error("ASSERT_VULKAN failed " + val);\
+            throw std::runtime_error("ASSERT_VULKAN failed " + std::to_string(val));\
         }
 #endif
 

--- a/src/descriptor_set.cpp
+++ b/src/descriptor_set.cpp
@@ -4,7 +4,7 @@
 #define ASSERT_VULKAN(val)\
         if(val!=VK_SUCCESS)\
         {\
-            throw std::runtime_error("ASSERT_VULKAN failed " + val);\
+            throw std::runtime_error("ASSERT_VULKAN failed " + std::to_string(val));\
         }
 #endif
 

--- a/src/image_view.cpp
+++ b/src/image_view.cpp
@@ -4,7 +4,7 @@
 #define ASSERT_VULKAN(val)\
         if(val!=VK_SUCCESS)\
         {\
-            throw std::runtime_error("ASSERT_VULKAN failed " + val);\
+            throw std::runtime_error("ASSERT_VULKAN failed " + std::to_string(val));\
         }
 #endif
 

--- a/src/makefile
+++ b/src/makefile
@@ -1,5 +1,5 @@
 CPPC := g++
-CFLAGS := -O3 -fPIC -Wall -Wextra
+CFLAGS := -O3 -fPIC -Wall -Wextra -Wno-unused-parameter
 LINKER :=  -shared -fvisibility=hidden
 
 BUILD_DIR := ../build

--- a/src/shader.cpp
+++ b/src/shader.cpp
@@ -4,7 +4,7 @@
 #define ASSERT_VULKAN(val)\
         if(val!=VK_SUCCESS)\
         {\
-            throw std::runtime_error("ASSERT_VULKAN failed " + val);\
+            throw std::runtime_error("ASSERT_VULKAN failed " + std::to_string(val));\
         }
 #endif
 


### PR DESCRIPTION
Unused parameter detection is incorrect in both GCC and clang.
Turn these warnings off until GCC and clang improve.

----

Fix invalid appending of error code

This issue was found by compiling the code with clang++ instead of g++.

For example, ("ASSERT_VULKAN failed "+3) yields "ERT_VULKAN failed ",
instead of "ASSERT_VULKAN failed 3".

----

Please merge. Thanks.