### PR TITLE
Allow empty/minimal config file

### DIFF
--- a/src/basalt.cpp
+++ b/src/basalt.cpp
@@ -369,7 +369,7 @@ VKAPI_ATTR VkResult VKAPI_CALL vkBasalt_GetSwapchainImagesKHR(VkDevice device, V
     std::cout << "device " << swapchainStruct.device << std::endl;
     
     
-    std::string effectOption = pConfig->getOption("effects");
+    std::string effectOption = pConfig->getOption("effects", "cas");
     std::vector<std::string> effectStrings;
     while(effectOption!=std::string(""))
     {

--- a/src/config.cpp
+++ b/src/config.cpp
@@ -74,7 +74,10 @@ namespace vkBasalt
         std::cout  << "set option " << line.substr(0,equal) << " equal to " << line.substr(equal+1) << std::endl;
         options[line.substr(0,equal)] = line.substr(equal+1);
     }
-    std::string Config::getOption(std::string option){
-        return options[option];
+    std::string Config::getOption(const std::string& option, const std::string& defaultValue) {
+        auto found = options.find(option);
+        return found != options.end()
+            ? found->second
+            : defaultValue;
     }
 }

--- a/src/config.hpp
+++ b/src/config.hpp
@@ -17,7 +17,7 @@ namespace vkBasalt{
     public:
         Config();
         Config(const Config& other);
-        std::string getOption(std::string option);
+        std::string getOption(const std::string& option, const std::string& defaultValue = "");
     private:
         std::unordered_map<std::string,std::string> options;
         void readConfigLine(std::string line);

--- a/src/effect_cas.cpp
+++ b/src/effect_cas.cpp
@@ -26,12 +26,7 @@ namespace vkBasalt
         std::string fullScreenRectFile = "full_screen_triangle.vert.spv";
         std::string casFragmentFile = "cas.frag.spv";
 
-        float sharpness = 0.4f;
-        //get config options
-        if(pConfig->getOption("casSharpness")!=std::string(""))
-        {
-            sharpness = std::stod(pConfig->getOption("casSharpness"));
-        }
+        float sharpness = std::stod(pConfig->getOption("casSharpness", "0.4"));
 
         shaderInfo.vertexCode = readFile(fullScreenRectFile);
         shaderInfo.fragmentCode = readFile(casFragmentFile);

--- a/src/effect_deband.cpp
+++ b/src/effect_deband.cpp
@@ -34,38 +34,24 @@ namespace vkBasalt
             float     screenHeight;
             float     reverseScreenWidth;
             float     reverseScreenHeight;
-            float     debandAvgdiff = 3.4;
-            float     debandMaxdiff = 6.8;
-            float     debandMiddiff = 3.3;
-            float     range = 16.0;
-            int32_t   iterations = 4;
-        } debandOptions;
+            float     debandAvgdiff;
+            float     debandMaxdiff;
+            float     debandMiddiff;
+            float     range;
+            int32_t   iterations;
+        } debandOptions {};
 
         debandOptions.screenWidth = (float) imageExtent.width;
         debandOptions.screenHeight = (float) imageExtent.height;
         debandOptions.reverseScreenWidth = 1.0f / imageExtent.width;
         debandOptions.reverseScreenHeight = 1.0f / imageExtent.height;
+
         //get Options
-        if(pConfig->getOption("debandAvgdiff")!=std::string(""))
-        {
-            debandOptions.debandAvgdiff = std::stod(pConfig->getOption("debandAvgdiff"));
-        }
-        if(pConfig->getOption("debandMaxdiff")!=std::string(""))
-        {
-            debandOptions.debandMaxdiff = std::stod(pConfig->getOption("debandMaxdiff"));
-        }
-        if(pConfig->getOption("debandMiddiff")!=std::string(""))
-        {
-            debandOptions.debandMiddiff = std::stod(pConfig->getOption("debandMiddiff"));
-        }
-        if(pConfig->getOption("debandRange")!=std::string(""))
-        {
-            debandOptions.range = std::stod(pConfig->getOption("debandRange"));
-        }
-        if(pConfig->getOption("debandIterations")!=std::string(""))
-        {
-            debandOptions.iterations = std::stod(pConfig->getOption("debandIterations"));
-        }
+        debandOptions.debandAvgdiff = std::stod(pConfig->getOption("debandAvgdiff", "3.4"));
+        debandOptions.debandMaxdiff = std::stod(pConfig->getOption("debandMaxdiff", "6.8"));
+        debandOptions.debandMiddiff = std::stod(pConfig->getOption("debandMiddiff", "3.3"));
+        debandOptions.range         = std::stod(pConfig->getOption("debandRange", "16.0"));
+        debandOptions.iterations    = std::stoi(pConfig->getOption("debandIterations", "4"));
 
         std::vector<VkSpecializationMapEntry> specMapEntrys(9);
         for(uint32_t i=0;i<specMapEntrys.size();i++)

--- a/src/effect_fxaa.cpp
+++ b/src/effect_fxaa.cpp
@@ -25,21 +25,10 @@ namespace vkBasalt
     {
         std::string fullScreenRectFile = "full_screen_triangle.vert.spv";
         std::string fxaaFragmentFile = "fxaa.frag.spv";
-        float fxaaQualitySubpix = 0.75f;
-        float fxaaQualityEdgeThreshold = 0.125f;
-        float fxaaQualityEdgeThresholdMin = 0.0312f;
-        if(pConfig->getOption("fxaaQualitySubpix")!=std::string(""))
-        {
-            fxaaQualitySubpix = std::stod(pConfig->getOption("fxaaQualitySubpix"));
-        }
-        if(pConfig->getOption("fxaaQualityEdgeThreshold")!=std::string(""))
-        {
-            fxaaQualityEdgeThreshold = std::stod(pConfig->getOption("fxaaQualityEdgeThreshold"));
-        }
-        if(pConfig->getOption("fxaaQualityEdgeThresholdMin")!=std::string(""))
-        {
-            fxaaQualityEdgeThresholdMin = std::stod(pConfig->getOption("fxaaQualityEdgeThresholdMin"));
-        }
+
+        float fxaaQualitySubpix = std::stod(pConfig->getOption("fxaaQualitySubpix", "0.75"));
+        float fxaaQualityEdgeThreshold = std::stod(pConfig->getOption("fxaaQualityEdgeThreshold", "0.125"));
+        float fxaaQualityEdgeThresholdMin = std::stod(pConfig->getOption("fxaaQualityEdgeThresholdMin", "0.0312"));
 
         shaderInfo.vertexCode   = readFile(fullScreenRectFile);
         shaderInfo.fragmentCode = readFile(fxaaFragmentFile);

--- a/src/effect_smaa.cpp
+++ b/src/effect_smaa.cpp
@@ -30,10 +30,10 @@ namespace vkBasalt
         float screenHeight;
         float reverseScreenWidth;
         float reverseScreenHeight;
-        float threshold = 0.05;
-        int32_t maxSearchSteps = 32;
-        int32_t maxSearchStepsDiag = 16;
-        int32_t cornerRounding = 25;
+        float threshold;
+        int32_t maxSearchSteps;
+        int32_t maxSearchStepsDiag;
+        int32_t cornerRounding;
     } SmaaOptions;
 
 
@@ -149,34 +149,16 @@ namespace vkBasalt
 
         //get config options
         SmaaOptions smaaOptions;
-        if(pConfig->getOption("smaaThreshold")!=std::string(""))
-        {
-            smaaOptions.threshold = std::stod(pConfig->getOption("smaaThreshold"));
-        }
-        if(pConfig->getOption("smaaMaxSearchSteps")!=std::string(""))
-        {
-            smaaOptions.maxSearchSteps = std::stoi(pConfig->getOption("smaaMaxSearchSteps"));
-        }
-        if(pConfig->getOption("smaaMaxSearchStepsDiag")!=std::string(""))
-        {
-            smaaOptions.maxSearchStepsDiag = std::stoi(pConfig->getOption("smaaMaxSearchStepsDiag"));
-        }
-        if(pConfig->getOption("smaaCornerRounding")!=std::string(""))
-        {
-            smaaOptions.cornerRounding = std::stoi(pConfig->getOption("smaaCornerRounding"));
-        }
+        smaaOptions.threshold           = std::stod(pConfig->getOption("smaaThreshold", "0.05"));
+        smaaOptions.maxSearchSteps      = std::stoi(pConfig->getOption("smaaMaxSearchSteps", "32"));
+        smaaOptions.maxSearchStepsDiag  = std::stoi(pConfig->getOption("smaaMaxSearchStepsDiag", "16"));
+        smaaOptions.cornerRounding      = std::stoi(pConfig->getOption("smaaCornerRounding", "25"));
 
-        auto shaderCode = readFile(smaaEdgeVertexFile.c_str());
+        auto shaderCode = readFile(smaaEdgeVertexFile);
         createShaderModule(device, dispatchTable, shaderCode, &edgeVertexModule);
-        if(pConfig->getOption("smaaEdgeDetection")==std::string("color"))
-        {
-            shaderCode = readFile(smaaEdgeColorFragmentFile.c_str());
-        }
-        else
-        {
-            shaderCode = readFile(smaaEdgeLumaFragmentFile.c_str());
-        }
-
+        shaderCode = pConfig->getOption("smaaEdgeDetection", "luma") == "color"
+            ? readFile(smaaEdgeColorFragmentFile)
+            : readFile(smaaEdgeLumaFragmentFile);
         createShaderModule(device, dispatchTable, shaderCode, &edgeFragmentModule);
         shaderCode = readFile(smaaBlendVertexFile);
         createShaderModule(device, dispatchTable, shaderCode, &blendVertexModule);


### PR DESCRIPTION
Don't crash if config file is empty.
All options initialized w/ default values.