### PR TITLE
Ensure that the project is friendlier with package-build systems

### DIFF
--- a/config/makefile
+++ b/config/makefile
@@ -1,11 +1,11 @@
-INSTALL_DIR := $(HOME)/.local/share/vulkan/implicit_layer.d
-LIB32 := $(HOME)/.local/share/vkBasalt/libvkbasalt32.so
-LIB64 := $(HOME)/.local/share/vkBasalt/libvkbasalt64.so
-CONFIG := $(HOME)/.local/share/vkBasalt/vkBasalt.conf
+INSTALL_DIR := $(DESTDIR)$(PREFIX)/share/vulkan/implicit_layer.d
+LIB32 := $(DESTDIR)$(PREFIX)/share/vkBasalt/libvkbasalt32.so
+LIB64 := $(DESTDIR)$(PREFIX)/share/vkBasalt/libvkbasalt64.so
+CONFIG := $(DESTDIR)$(PREFIX)/share/vkBasalt/vkBasalt.conf
+SED ?= sed
 
-install: 
+install:
 	mkdir -p $(INSTALL_DIR)
-	sed 's+@lib+$(LIB32)+g' vkBasalt32.json > $(INSTALL_DIR)/vkBasalt32.json
-	sed 's+@lib+$(LIB64)+g' vkBasalt64.json > $(INSTALL_DIR)/vkBasalt64.json
+	$(SED) 's+@lib+$(LIB32)+g' vkBasalt32.json > $(INSTALL_DIR)/vkBasalt32.json
+	$(SED) 's+@lib+$(LIB64)+g' vkBasalt64.json > $(INSTALL_DIR)/vkBasalt64.json
 	install -m 0644 -D -T vkBasalt.conf $(CONFIG)
-	

--- a/makefile
+++ b/makefile
@@ -1,9 +1,18 @@
 DIRS = src shader
 INSTALL_DIRS = src shader config
+DESTDIR ?= $(HOME)
+PREFIX ?= /.local
+
+export DESTDIR PREFIX
+
 compile:
 	for i in $(DIRS); do $(MAKE) -C $$i; done
-	
+
 install:
 	for i in $(INSTALL_DIRS); do $(MAKE) install -C $$i; done
-	
-	
+
+uninstall:
+	rm -rf $(DESTDIR)$(PREFIX)/share/vkBasalt
+
+clean:
+	rm -rf build

--- a/shader/makefile
+++ b/shader/makefile
@@ -1,7 +1,7 @@
 BUILD_DIR := ../build/shader
 BUILD_DIR_TMP := ../build/tmp
 
-INSTALL_DIR := $(HOME)/.local/share/vkBasalt/shader/
+INSTALL_DIR := $(DESTDIR)$(PREFIX)/share/vkBasalt/shader/
 
 SRC_FILES := $(wildcard *.glsl)
 TMP_FILES := $(foreach file,$(patsubst %.glsl,%.spv,$(SRC_FILES)),$(BUILD_DIR_TMP)/$(file))
@@ -20,9 +20,7 @@ $(BUILD_DIR_TMP)/%.spv: %.glsl $(BUILD_DIR_TMP)
 
 $(BUILD_DIR_TMP):
 	mkdir -p $(BUILD_DIR_TMP)
-	
-	
+
 install:
 	mkdir -p $(INSTALL_DIR)
 	install -m 0644 -t  $(INSTALL_DIR)  $(SPV_FILES)
-	

--- a/src/makefile
+++ b/src/makefile
@@ -1,36 +1,32 @@
-CPPC := g++
-CFLAGS := -std=c++17 -O3 -fPIC -Wall -Wextra -Wno-unused-parameter
-LINKER :=  -shared  -lstdc++fs -fvisibility=hidden
+CXX ?= g++
+CXXFLAGS ?= -O3 -fPIC -Wall -Wextra -Wno-unused-parameter
+CXXFLAGS += -std=c++17
+LDFLAGS +=  -shared -lstdc++fs -fvisibility=hidden
 
 BUILD_DIR := ../build
-INSTALL_DIR := $(HOME)/.local/share/vkBasalt
+INSTALL_DIR := $(DESTDIR)$(PREFIX)/share/vkBasalt
 
 SRC_FILES := $(wildcard *.cpp)
 OBJ_FILES64 := $(foreach file,$(patsubst %.cpp,%.64.o,$(SRC_FILES)),$(BUILD_DIR)/$(file))
 OBJ_FILES32 := $(foreach file,$(patsubst %.cpp,%.32.o,$(SRC_FILES)),$(BUILD_DIR)/$(file))
 
-
 all: $(BUILD_DIR)/libvkbasalt64.so $(BUILD_DIR)/libvkbasalt32.so
 
 $(BUILD_DIR)/libvkbasalt64.so: $(OBJ_FILES64)
-	$(CPPC) -o $@ $^ $(CFLAGS) $(LINKER) -m64
-	
+	$(CXX) -o $@ $^ $(CXXFLAGS) $(LDFLAGS) -m64
+
 $(BUILD_DIR)/libvkbasalt32.so: $(OBJ_FILES32)
-	$(CPPC) -o $@ $^ $(CFLAGS) $(LINKER) -m32
+	$(CXX) -o $@ $^ $(CXXFLAGS) $(LDFLAGS) -m32
 
 $(BUILD_DIR)/%.64.o: %.cpp $(BUILD_DIR)
-	$(CPPC) $< -o $@ -c  $(CFLAGS) -m64
+	$(CXX) $< -o $@ -c  $(CXXFLAGS) -m64
 
 $(BUILD_DIR)/%.32.o: %.cpp $(BUILD_DIR)
-	$(CPPC) $< -o $@ -c  $(CFLAGS) -m32
+	$(CXX) $< -o $@ -c  $(CXXFLAGS) -m32
 
 $(BUILD_DIR):
 	mkdir -p $(BUILD_DIR)
-	
-install: 
+
+install:
 	install -m 0755 -D -T $(BUILD_DIR)/libvkbasalt64.so $(INSTALL_DIR)/libvkbasalt64.so
 	install -m 0755 -D -T $(BUILD_DIR)/libvkbasalt32.so $(INSTALL_DIR)/libvkbasalt32.so
-
-    
-
-


### PR DESCRIPTION
Allows to build a package without requiring any patches, selecting custom C++ compilers and flags with the `CXX` `CXXFLAGS` `LDFLAGS` envars and setting the installation directory with `DESTDIR` and `PREFIX` (run `make install` for an installation at `$DESTDIR$PREFIX`), instead of `$HOME/.local` (which will remain as the default one).