### PR TITLE
Add XDG_CONFIG_HOME to config file finding

### DIFF
--- a/README.md
+++ b/README.md
@@ -79,6 +79,7 @@ Settings like the CAS sharpening strength can be changed in the config file.
 The config file will be searched for in the following locations:
 * a file set with the environment variable`VKBASALT_CONFIG_FILE=/path/to/vkBasalt.conf`
 * `vkBasalt.conf` in the working directory of the game
+* `$XDG_CONFIG_HOME/vkBasalt/vkBasalt.conf` or `~/.config/vkBasalt/vkBasalt.conf` if `XDG_CONFIG_HOME` is not set
 * `$XDG_DATA_HOME/vkBasalt/vkBasalt.conf` or `~/.local/share/vkBasalt/vkBasalt.conf` if `XDG_DATA_HOME` is not set
 * `/usr/share/vkBasalt/vkBasalt.conf`
 * `/usr/local/share/vkBasalt/vkBasalt.conf`

--- a/src/config.cpp
+++ b/src/config.cpp
@@ -13,11 +13,16 @@ namespace vkBasalt
         std::string userConfigFile = tmpHomeEnv
             ? std::string(tmpHomeEnv) + "/vkBasalt/vkBasalt.conf"
             : std::string(std::getenv("HOME")) + "/.local/share/vkBasalt/vkBasalt.conf";
+        const char* tmpConfigEnv = std::getenv("XDG_CONFIG_HOME");
+        std::string userXdgConfigFile = tmpConfigEnv
+            ? std::string(tmpConfigEnv) + "/vkBasalt/vkBasalt.conf"
+            : std::string(std::getenv("HOME")) + "/.config/vkBasalt/vkBasalt.conf";
 
         // Allowed config paths
-        const std::array<std::string, 5> configPath = {
+        const std::array<std::string, 6> configPath = {
             customConfigFile,                          // custom config (VKBASALT_CONFIG_FILE=/path/to/vkBasalt.conf)
             "vkBasalt.conf",                           // per game config
+            userXdgConfigFile,                         // user-global config
             userConfigFile,                            // default config
             "/usr/share/vkBasalt/vkBasalt.conf",       // system-wide config
             "/usr/local/share/vkBasalt/vkBasalt.conf", // system-wide config (alternative)


### PR DESCRIPTION
This patchset adds `XDG_CONFIG_HOME` (default: `~/.config`) to the list of places to search for config files.

As a user, I'm more used to configuration files existing there, so it makes sense to search it right before the search in `XDG_DATA_HOME` (default: `~/.local/share`).