### PR TITLE
Improve reshade configuration

### DIFF
--- a/src/effect_reshade.cpp
+++ b/src/effect_reshade.cpp
@@ -234,7 +234,9 @@ namespace vkBasalt
                         break;
                 }
 
-                std::string          filePath = pConfig->getOption<std::string>("reshadeTexturePath") + "/" + source->value.string_data;
+                std::string          filePath = pConfig->getOption<std::string>("reshadeTexturePath",
+                                                                                pConfig->getOption<std::string>("reshadePath") + "/Textures") +
+                                                                                "/" + source->value.string_data;
                 stbi_uc*             pixels;
                 std::vector<stbi_uc> resizedPixels;
                 uint32_t             size;
@@ -566,7 +568,8 @@ namespace vkBasalt
             {
                 if (!opt.name.empty())
                 {
-                    std::string val = pConfig->getOption<std::string>(opt.name);
+                    std::string opt_name = effectName + "_" + opt.name;
+                    std::string val = pConfig->getOption<std::string>(opt_name);
                     if (!val.empty())
                     {
                         std::variant<int32_t, uint32_t, float> convertedValue;
@@ -574,25 +577,25 @@ namespace vkBasalt
                         switch (opt.type.base)
                         {
                             case reshadefx::type::t_bool:
-                                convertedValue = (int32_t) pConfig->getOption<bool>(opt.name);
+                                convertedValue = (int32_t) pConfig->getOption<bool>(opt_name);
                                 specData.resize(offset + sizeof(VkBool32));
                                 std::memcpy(specData.data() + offset, &convertedValue, sizeof(VkBool32));
                                 specMapEntrys.push_back({specId, offset, sizeof(VkBool32)});
                                 break;
                             case reshadefx::type::t_int:
-                                convertedValue = pConfig->getOption<int32_t>(opt.name);
+                                convertedValue = pConfig->getOption<int32_t>(opt_name);
                                 specData.resize(offset + sizeof(int32_t));
                                 std::memcpy(specData.data() + offset, &convertedValue, sizeof(int32_t));
                                 specMapEntrys.push_back({specId, offset, sizeof(int32_t)});
                                 break;
                             case reshadefx::type::t_uint:
-                                convertedValue = (uint32_t) pConfig->getOption<int32_t>(opt.name);
+                                convertedValue = (uint32_t) pConfig->getOption<int32_t>(opt_name);
                                 specData.resize(offset + sizeof(uint32_t));
                                 std::memcpy(specData.data() + offset, &convertedValue, sizeof(uint32_t));
                                 specMapEntrys.push_back({specId, offset, sizeof(uint32_t)});
                                 break;
                             case reshadefx::type::t_float:
-                                convertedValue = pConfig->getOption<float>(opt.name);
+                                convertedValue = pConfig->getOption<float>(opt_name);
                                 specData.resize(offset + sizeof(float));
                                 std::memcpy(specData.data() + offset, &convertedValue, sizeof(float));
                                 specMapEntrys.push_back({specId, offset, sizeof(float)});
@@ -1132,10 +1135,21 @@ namespace vkBasalt
         preprocessor.add_macro_definition("BUFFER_RCP_WIDTH", "(1.0 / BUFFER_WIDTH)");
         preprocessor.add_macro_definition("BUFFER_RCP_HEIGHT", "(1.0 / BUFFER_HEIGHT)");
         preprocessor.add_macro_definition("BUFFER_COLOR_DEPTH", (inputOutputFormatUNORM == VK_FORMAT_A2R10G10B10_UNORM_PACK32) ? "10" : "8");
-        preprocessor.add_include_path(pConfig->getOption<std::string>("reshadeIncludePath"));
-        if (!preprocessor.append_file(pConfig->getOption<std::string>(effectName)))
+
+        std::string includePath = pConfig->getOption<std::string>("reshadeShaderPath",
+                                                                  pConfig->getOption<std::string>("reshadeIncludePath",
+                                                                  pConfig->getOption<std::string>("reshadePath") + "/Shaders"));
+        std::string effectPath  = pConfig->getOption<std::string>(effectName, effectName);
+
+        if (effectPath[0] != '/')
         {
-            Logger::err("failed to load shader file: " + pConfig->getOption<std::string>(effectName));
+            effectPath = includePath + "/" + effectPath;
+        }
+
+        preprocessor.add_include_path(includePath);
+        if (!preprocessor.append_file(effectPath) && !preprocessor.append_file(effectPath + ".fx"))
+        {
+            Logger::err("failed to load shader file: " + effectPath);
             Logger::err("Does the filepath exist and does it not include spaces?");
         }
 


### PR DESCRIPTION
This is an attempt to simplify ReShade configuration while maintaining backwards compatibility. It allows you to specify the shader filename in `effects` and the path to the reshade-shaders folder in `reshadePath` (the folder must contain "Shaders" and "Textures" dirs), e.g
```
effects = monochrome.fx
reshadePath = /usr/share/reshade
```
You can specify the shaders with the `.fx` extension or not. If there's a name conflict in the future the vkBasalt effect will take priority so using `.fx` is probably better, and it's clearer that it's a ReShade shader.

`reshadeIncludePath` and `reshadeTexturePath` are higher priority than `reshadePath`. I also added `reshadeShaderPath` for specifying the Shaders dir because its name is more intuitive.

You can still specify the shader with a path i.e
```
effects = monochrome.fx
monochrome = /usr/share/reshade/Shaders/Monochrome.fx
```
But If it's a relative path it's added to the shader path.

And finally the settings for ReShade shaders are now specified with the shader name as prefixes (so they don't clash + better readability). e.g
```
effects = Technicolor.fx
Technicolor_Strength = 1
```