### PR TITLE
Added a warning for using same variable name as a reshade shader

### DIFF
--- a/README.md
+++ b/README.md
@@ -23,7 +23,7 @@ Before building, you will need:
 
 ### Building
 
-**These instructions use `--prefix=/usr`, which is generally not recommened since vkBasalt will be installed in directories that are meant for the package manager. The alternative is not setting the prefix, it will then be installed in `/usr/local`. But you need to make sure that `ld` finds the library since /usr/local is very likely not in the default path.** 
+**These instructions use `--prefix=/usr`, which is generally not recommened since vkBasalt will be installed in directories that are meant for the package manager. The alternative is not setting the prefix, it will then be installed in `/usr/local`. But you need to make sure that `ld` finds the library since /usr/local is very likely not in the default path.**
 
 In general, prefer using distro provided packages.
 
@@ -64,7 +64,7 @@ With Lutris, follow these steps below:
 ### Steam
 With Steam, edit your launch options and add:
 ```ini
-ENABLE_VKBASALT=1 %command% 
+ENABLE_VKBASALT=1 %command%
 ```
 
 ## Configure

--- a/README.md
+++ b/README.md
@@ -87,13 +87,28 @@ If you want to make changes for one game only, you can create a file named `vkBa
 To run reshade fx shaders e.g. shaders from the [reshade repo](https://github.com/crosire/reshade-shaders), you have to set `reshadeTexturePath` and `reshadeIncludePath` to the matching dirctories from the repo. To then use a specific shader you need to set a custom effect name to the shader path and then add that effect name to `effects` like every other effect.
 
 ```ini
-effects = colorfulness:denoise
+effects = colourful:denoise
 
-colorfulness = /home/user/reshade-shaders/Shaders/Colourfulness.fx
+colourful = /home/user/reshade-shaders/Shaders/Colourfulness.fx
 denoise = /home/user/reshade-shaders/Shaders/Denoise.fx
 reshadeTexturePath = /home/user/reshade-shaders/Textures
 reshadeIncludePath = /home/user/reshade-shaders/Shaders
 ```
+
+*Attention*
+
+If the custom name you chose matches one used by a setting in the reshade shaders, you'll get an error.
+This config
+
+```ini
+ effects = colourfulness
+
+ colourfulness = /home/user/reshade-shaders/Shaders/Colourfulness.fx
+ reshadeTexturePath = /home/user/reshade-shaders/Textures
+ reshadeIncludePath = /home/user/reshade-shaders/Shaders
+```
+
+leads to *vkBasalt warn:  invalid float value for: colourfulness*.
 
 #### Ingame Input
 


### PR DESCRIPTION
As mentioned in #93 , I thought this could be clearer.

Your current edit may not fail, but you have to pay attention to colorfulness vs colorfulness which I'm thinking many will not see till failing too many times. I did not see that until I saw your commit. :)

I also think a warning would be good since the error message isn't clear about what the problem is.

Of course I'm open to any change needed.