### PR TITLE
add option to install library to private directory

### DIFF
--- a/config/meson.build
+++ b/config/meson.build
@@ -2,5 +2,10 @@ data_dir = get_option('datadir')
 
 vulkan_layer_dir = join_paths(data_dir, 'vulkan', 'implicit_layer.d')
 
-install_data(['vkBasalt.json'],
-    install_dir: vulkan_layer_dir)
+configure_file(
+    input : 'vkBasalt.json.in',
+    output : 'vkBasalt.json',
+    configuration : {'ld_lib_dir_vkbasalt' : ld_lib_dir_vkbasalt},
+    install : true,
+    install_dir : vulkan_layer_dir,
+)

--- a/config/vkBasalt.json.in
+++ b/config/vkBasalt.json.in
@@ -3,7 +3,7 @@
   "layer" : {
     "name": "VK_LAYER_VKBASALT_post_processing",
     "type": "GLOBAL",
-    "library_path": "libvkbasalt.so",
+    "library_path": "@ld_lib_dir_vkbasalt@libvkbasalt.so",
     "api_version": "1.2.136",
     "implementation_version": "1",
     "description": "a post processing layer",

--- a/meson.build
+++ b/meson.build
@@ -2,6 +2,14 @@ project('vkBasalt', ['c', 'cpp'], default_options: ['c_std=c11', 'cpp_std=c++2a'
 
 vkBasalt_include_path = include_directories('./include', './include/spirv')
 
+lib_dir = get_option('libdir')
+ld_lib_dir_vkbasalt = ''
+
+if get_option('append_libdir_vkbasalt')
+    lib_dir = join_paths(lib_dir, 'vkbasalt')
+    ld_lib_dir_vkbasalt = get_option('prefix') + '/\$LIB/vkbasalt/'
+endif
+
 if get_option('with_so')
     subdir('src')
 endif

--- a/meson_options.txt
+++ b/meson_options.txt
@@ -1,2 +1,3 @@
 option('with_so', type : 'boolean', value : true, description : 'install the library')
 option('with_json', type : 'boolean', value : true, description : 'install the json')
+option('append_libdir_vkbasalt', type : 'boolean', value : false, description: 'Append "vkbasalt" to libdir path or not.')

--- a/src/meson.build
+++ b/src/meson.build
@@ -40,8 +40,6 @@ vkBasalt_src = [
 
 x11_dep = dependency('x11')
 
-lib_dir = get_option('libdir')
-
 shared_library(meson.project_name().to_lower(), 
     vkBasalt_src, shader_include,
     include_directories : vkBasalt_include_path,


### PR DESCRIPTION
This is basically the same as https://github.com/flightlessmango/MangoHud/pull/273 and https://github.com/flightlessmango/MangoHud/tree/ld-preload-2.
It doesn't change the default behavior, but it allows to install vkBasalt library to a "private" directory. The idea here is that usually, libs inside `/usr/lib64/libxy.so` or `/usr/lib/x86_64-linxu-gnu/libxy.so` are _shared_ libs, i. e. they can be used by multiple applications. There are several expectations to such libraries, for example a soversion or even a version map file.
Obviously, this all doesn't make sense for vkBasalt (but ofc these are all "guidelines", so it will still work ofc). This simply adds an option to install vkBasalt to a subdir. The `\$LIB` trick basically is the `libdir` option of Meson, just applied on runtime by `ld`.