### PR TITLE
Fix lib install

### DIFF
--- a/src/meson.build
+++ b/src/meson.build
@@ -44,4 +44,5 @@ shared_library(meson.project_name().to_lower(),
     vkBasalt_src, shader_include,
     include_directories : vkBasalt_include_path,
     dependencies : [x11_dep, reshade_dep],
-    install : lib_dir)
+    install : true,
+    install_dir : lib_dir)


### PR DESCRIPTION
Currently, the `lib_dir` option is used as a boolean to determine if we should install the library (thus #97 has no effect on installation path).
I guess it's typo, we should always install the library, and use the option to determine the directory to install to.
