### PR TITLE
Configure system-wide paths at build time

### DIFF
--- a/src/config.cpp
+++ b/src/config.cpp
@@ -1,4 +1,5 @@
 #include "config.hpp"
+#include "config_paths.hpp"
 
 #include <sstream>
 #include <locale>
@@ -20,15 +21,14 @@ namespace vkBasalt
                                                      : std::string(std::getenv("HOME")) + "/.config/vkBasalt/vkBasalt.conf";
 
         // Allowed config paths
-        const std::array<std::string, 8> configPath = {
-            customConfigFile,                          // custom config (VKBASALT_CONFIG_FILE=/path/to/vkBasalt.conf)
-            "vkBasalt.conf",                           // per game config
-            userXdgConfigFile,                         // user-global config
-            userConfigFile,                            // legacy default config
-            "/etc/vkBasalt.conf",                      // system-wide config
-            "/etc/vkBasalt/vkBasalt.conf",             // system-wide config (alternative)
-            "/usr/share/vkBasalt/vkBasalt.conf",       // legacy system-wide config
-            "/usr/local/share/vkBasalt/vkBasalt.conf", // legacy system-wide config (alternative)
+        const std::array<std::string, 7> configPath = {
+            customConfigFile,                                    // custom config (VKBASALT_CONFIG_FILE=/path/to/vkBasalt.conf)
+            "vkBasalt.conf",                                     // per game config
+            userXdgConfigFile,                                   // user-global config
+            userConfigFile,                                      // legacy default config
+            std::string(SYSCONFDIR) + "/vkBasalt.conf",          // system-wide config
+            std::string(SYSCONFDIR) + "/vkBasalt/vkBasalt.conf", // system-wide config (alternative)
+            std::string(DATADIR) + "/vkBasalt/vkBasalt.conf",    // legacy system-wide config
         };
 
         for (const auto& cFile : configPath)

--- a/src/meson.build
+++ b/src/meson.build
@@ -40,6 +40,13 @@ vkBasalt_src = [
 
 x11_dep = dependency('x11')
 
+conf_paths = configuration_data()
+conf_paths.set_quoted('SYSCONFDIR', join_paths(get_option('prefix'), get_option('sysconfdir')))
+conf_paths.set_quoted('DATADIR', join_paths(get_option('prefix'), get_option('datadir')))
+
+configure_file(output: 'config_paths.hpp',
+               configuration : conf_paths)
+
 shared_library(meson.project_name().to_lower(), 
     vkBasalt_src, shader_include,
     include_directories : vkBasalt_include_path,


### PR DESCRIPTION
Hardcoded `/etc` and `/usr/share` paths might work for most cases, but are invalid for distribution with other install prefix, like in flatpak packages or NixOS. Let meson configure the paths instead of using static values.