### PR TITLE
fix: Add <algorithm> include. Fixes build on GCC12

### DIFF
--- a/src/reshade/effect_preprocessor.cpp
+++ b/src/reshade/effect_preprocessor.cpp
@@ -6,6 +6,7 @@
 #include "effect_lexer.hpp"
 #include "effect_preprocessor.hpp"
 #include <cassert>
+#include <algorithm>
 
 #ifndef _WIN32
 	// On Linux systems the native path encoding is UTF-8 already, so no conversion necessary


### PR DESCRIPTION
vkBasalt fails to build with new GCC 12 due missing `<algorithm>` include in `effect_preprocessor.cpp`. Could potentially affect all Linux distrubtion in near future.

https://www.cplusplus.com/reference/algorithm/find_if/