### PR TITLE
Bump layer api_version to 1.3.0

### DIFF
--- a/config/vkBasalt.json.in
+++ b/config/vkBasalt.json.in
@@ -4,7 +4,7 @@
     "name": "VK_LAYER_VKBASALT_post_processing",
     "type": "GLOBAL",
     "library_path": "@ld_lib_dir_vkbasalt@libvkbasalt.so",
-    "api_version": "1.2.136",
+    "api_version": "1.3.0",
     "implementation_version": "1",
     "description": "a post processing layer",
     "functions": {


### PR DESCRIPTION
vkBasalt fails silently on systems with a vulkan-loader >= 1.3.0, so update api_version to 1.3.0.