### PR TITLE
Document `DISABLE_VKBASALT` environment variable in README

### DIFF
--- a/README.md
+++ b/README.md
@@ -65,6 +65,12 @@ When using the terminal or an application (.desktop) file, execute:
 ENABLE_VKBASALT=1 yourgame
 ```
 
+If you've enabled vkBasalt globally, you can disable it for a specific application using:
+
+```ini
+DISABLE_VKBASALT=1 yourgame
+```
+
 ### Lutris
 With Lutris, follow these steps below:
 1. Right click on a game, and press `configure`.


### PR DESCRIPTION
This is useful to disable vkBasalt for a specific application when vkBasalt is globally enabled on the system. This specifically avoids issues in situations where environment variables cannot be unset or overridden for some reason.

See https://github.com/godotengine/godot/pull/71515#issuecomment-1385193268 where we discovered this environment variable by chance :slightly_smiling_face:
