### PR TITLE
VkDestroySwapchainKHR: Account for destroying null chains (Fix usage w/ mpv's waylandvk implementation)

### DIFF
--- a/src/basalt.cpp
+++ b/src/basalt.cpp
@@ -603,10 +603,12 @@ namespace vkBasalt
         // we need to delete the infos of the oldswapchain
 
         Logger::trace("vkDestroySwapchainKHR " + convertToString(swapchain));
-        swapchainMap[swapchain]->destroy();
-        swapchainMap.erase(swapchain);
-        LogicalDevice* pLogicalDevice = deviceMap[GetKey(device)].get();
+        if (swapchain != VK_NULL_HANDLE || swapchainMap.contains(swapchain)) {
+            swapchainMap[swapchain]->destroy();
+            swapchainMap.erase(swapchain);
+        }
 
+        LogicalDevice* pLogicalDevice = deviceMap[GetKey(device)].get();
         pLogicalDevice->vkd.DestroySwapchainKHR(device, swapchain, pAllocator);
     }
 


### PR DESCRIPTION
`mpv`, as an example, behaves poorly, and will call `vkDestroySwapchainKHR` with `VK_NULL_HANDLE` as the swapchain upon init. It seems that **downstream drivers tend to handle this gracefully**, so we can check to make sure that the swapchain is either non-null (so we should expect to have a reference to ours), or we *do* have a reference to a VK_NULL_HANDLE swapchain (unexpected, but... maybe?) before we dereference it, thereby allowing the layer to be used with such poorly-behaved applications.

While I'd agree that we *shouldn't* have to support this case here, the cost is minimal to just check for VK_NULL_HANDLE (which will 99.99% of the time be untrue), and the benefit of supporting calling `vkDestroySwapchainKHR` with null swapchains is allowing for support for these poorly-behaved applications out in the wild.

For non-null swapchain handles, this will still crash (as expected), so as to maintain visibility of the error path here in unintended cases, but will try to dereference and call `destroy()` on `VK_NULL_HANDLE` chains if and only if we have somehow accumulated one in `swapchainMap` (by, for instance, a driver or other layer passing us `VK_NULL_HANDLE` as a "valid" swapchain). This *shouldn't* ever be the case either, but defensive coding here can cover the problem cases, with minimal unintended impact to the flow where the application/driver follow the specification.