### PR TITLE
fix: crash on cast from float to float in reshade shaders

### DIFF
--- a/src/reshade/effect_codegen_spirv.cpp
+++ b/src/reshade/effect_codegen_spirv.cpp
@@ -1138,7 +1138,7 @@ private:
 						.add(emit_constant(op.from, 0))
 						.result;
 				}
-				else
+				else if (op.to != op.from)
 				{
 					spv::Op spv_op = spv::OpNop;
 


### PR DESCRIPTION
Allow redundant casts by not generating instructions for them.