### PR TITLE
SMAA depth edge detection

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -3,3 +3,4 @@
 *.so
 *.o
 build*/
+.vscode/

--- a/config/vkBasalt.conf
+++ b/config/vkBasalt.conf
@@ -67,16 +67,46 @@ fxaaQualityEdgeThreshold = 0.125
 fxaaQualityEdgeThresholdMin = 0.0312
 
 #smaaEdgeDetection changes the edge detection shader
-#luma  - default
-#color - might catch more edges, but is more expensive
-smaaEdgeDetection = luma
+#0 - luma  - default
+#1 - color - might catch more edges, but is more expensive
+#2 - depth - uses depth buffer to find edges, doesn't touch UI. Doesn't fix texture aliasing.
+smaaEdgeDetection = 1
 
-#smaaThreshold specifies the threshold or sensitivity to edges
+#smaaThreshold specifies the threshold or sensitivity to edges in luma or color modes
 #Lowering this value you will be able to detect more edges at the expense of performance.
 #Range: [0, 0.5]
 #0.1 is a reasonable value, and allows to catch most visible edges.
 #0.05 is a rather overkill value, that allows to catch 'em all.
 smaaThreshold = 0.05
+
+#smaaDepthThreshold specifies the threshold or sensitivity to edges in depth mode
+#Lowering this value you will be able to detect more edges at the expense of performance.
+#Range: [0, 0.1]
+#0.010 is a reasonable value, and allows to catch most geometry edges.
+#0.003 is a rather overkill value, may have false positives at shallow angles.
+smaaDepthThreshold = 0.01
+
+#depthInputIsUpsideDown flips the depth buffer vertically
+#0 - no flip
+#1 - flip
+depthInputIsUpsideDown = 0
+
+#depthInputIsReverse inverts the depth stored in the depth buffer
+#0 - no flip
+#1 - flip
+depthInputIsReverse = 0
+
+#depthInputIsLogarithmic tells the shader whether the input is logarithmic or not
+#You may see stripes or waves in the depth buffer if this is set incorrectly
+#0 - not logarithmic
+#1 - logarithmic
+depthInputIsLogarithmic = 0
+
+#depthMultiplier multiplies the depth values by the given number (float)
+depthMultiplier = 1.0
+
+#depthLinearizationFarPlane sets the far edge of the linearisation process
+depthLinearizationFarPlane = 1000.0
 
 #smaaMaxSearchSteps specifies the maximum steps performed in the horizontal/vertical pattern searches
 #Range: [0, 112]

--- a/src/basalt.cpp
+++ b/src/basalt.cpp
@@ -61,6 +61,8 @@ namespace vkBasalt
     std::unordered_map<VkSwapchainKHR, std::shared_ptr<LogicalSwapchain>> swapchainMap;
 
     std::mutex globalLock;
+
+    VkExtent2D currentSwapchainExtent;
 #ifdef _GCC_
     using scoped_lock __attribute__((unused)) = std::lock_guard<std::mutex>;
 #else
@@ -364,6 +366,8 @@ namespace vkBasalt
 
         swapchainMap[*pSwapchain] = pLogicalSwapchain;
 
+        currentSwapchainExtent = pCreateInfo->imageExtent;
+
         return result;
     }
 
@@ -644,8 +648,11 @@ namespace vkBasalt
             VkImageCreateInfo modifiedCreateInfo = *pCreateInfo;
             modifiedCreateInfo.usage |= VK_IMAGE_USAGE_SAMPLED_BIT;
             VkResult result = pLogicalDevice->vkd.CreateImage(device, &modifiedCreateInfo, pAllocator, pImage);
+            if (pCreateInfo->extent.width == currentSwapchainExtent.width) {
+                Logger::debug("depth image matches swapchain width of " + std::to_string(pCreateInfo->extent.width) + ", adding to depth image list");
             pLogicalDevice->depthImages.push_back(*pImage);
             pLogicalDevice->depthFormats.push_back(pCreateInfo->format);
+            }
 
             return result;
         }

--- a/src/effect_smaa.cpp
+++ b/src/effect_smaa.cpp
@@ -57,6 +57,8 @@ namespace vkBasalt
         Logger::debug("created output ImageViews");
         sampler = createSampler(pLogicalDevice);
         Logger::debug("created sampler");
+        depthSampler = createDepthSampler(pLogicalDevice);
+        Logger::debug("created depth sampler");
 
         VkExtent3D areaImageExtent = {AREATEX_WIDTH, AREATEX_HEIGHT, 1};
 
@@ -87,12 +89,12 @@ namespace vkBasalt
         searchImageView = createImageViews(pLogicalDevice, VK_FORMAT_R8_UNORM, std::vector<VkImage>(1, searchImage))[0];
         Logger::debug("created search ImageView");
 
-        imageSamplerDescriptorSetLayout = createImageSamplerDescriptorSetLayout(pLogicalDevice, 5);
+        imageSamplerDescriptorSetLayout = createImageSamplerDescriptorSetLayout(pLogicalDevice, 6);
         Logger::debug("created descriptorSetLayouts");
 
         VkDescriptorPoolSize imagePoolSize;
         imagePoolSize.type            = VK_DESCRIPTOR_TYPE_COMBINED_IMAGE_SAMPLER;
-        imagePoolSize.descriptorCount = inputImages.size() * 5;
+        imagePoolSize.descriptorCount = inputImages.size() * 6;
 
         std::vector<VkDescriptorPoolSize> poolSizes = {imagePoolSize};
 
@@ -107,23 +109,54 @@ namespace vkBasalt
             float   reverseScreenWidth;
             float   reverseScreenHeight;
             float   threshold;
+            float   depthThreshold;
             int32_t maxSearchSteps;
             int32_t maxSearchStepsDiag;
             int32_t cornerRounding;
+            // Depth settings
+            int32_t depthInputIsUpsideDown;
+            int32_t depthInputIsReverse;
+            int32_t depthInputIsLogarithmic;
+            float   depthMultiplier;
+            float   depthLinearizationFarPlane;
         };
 
         SmaaOptions smaaOptions;
         smaaOptions.threshold          = pConfig->getOption<float>("smaaThreshold", 0.05f);
+        smaaOptions.depthThreshold     = pConfig->getOption<float>("smaaDepthThreshold", 0.05f);
         smaaOptions.maxSearchSteps     = pConfig->getOption<int32_t>("smaaMaxSearchSteps", 32);
         smaaOptions.maxSearchStepsDiag = pConfig->getOption<int32_t>("smaaMaxSearchStepsDiag", 16);
         smaaOptions.cornerRounding     = pConfig->getOption<int32_t>("smaaCornerRounding", 25);
+        int detectionType              = pConfig->getOption<int32_t>("smaaEdgeDetection", 0);
+
+        smaaOptions.depthInputIsUpsideDown      = pConfig->getOption<int32_t>("depthInputIsUpsideDown", 0);
+        smaaOptions.depthInputIsReverse         = pConfig->getOption<int32_t>("depthInputIsReverse", 0);
+        smaaOptions.depthInputIsLogarithmic     = pConfig->getOption<int32_t>("depthInputIsLogarithmic", 0);
+        smaaOptions.depthMultiplier             = pConfig->getOption<float>("depthMultiplier", 1.0f);
+        smaaOptions.depthLinearizationFarPlane  = pConfig->getOption<float>("depthLinearizationFarPlane", 1000.f);
+
+        auto smaa_edge_frag = smaa_edge_luma_frag;
+
+        switch (detectionType)
+        {
+            case 1:
+                smaa_edge_frag = smaa_edge_color_frag;
+                Logger::debug("Using color detection in SMAA");
+                break;
+            
+            case 2:
+                smaa_edge_frag = smaa_edge_depth_frag;
+                Logger::debug("Using depth detection in SMAA");
+                break;
+                
+            default:
+                Logger::debug("Using luma detection in SMAA");
+                break;
+        }
 
         createShaderModule(pLogicalDevice, smaa_edge_vert, &edgeVertexModule);
 
-        bool useColor = pConfig->getOption<std::string>("smaaEdgeDetection", "luma") == "color";
-
-        auto shaderCode = useColor ? smaa_edge_color_frag : smaa_edge_luma_frag;
-        createShaderModule(pLogicalDevice, shaderCode, &edgeFragmentModule);
+        createShaderModule(pLogicalDevice, smaa_edge_frag, &edgeFragmentModule);
 
         createShaderModule(pLogicalDevice, smaa_blend_vert, &blendVertexModule);
 
@@ -139,7 +172,7 @@ namespace vkBasalt
         std::vector<VkDescriptorSetLayout> descriptorSetLayouts = {imageSamplerDescriptorSetLayout};
         pipelineLayout                                          = createGraphicsPipelineLayout(pLogicalDevice, descriptorSetLayouts);
 
-        std::vector<VkSpecializationMapEntry> specMapEntrys(8);
+        std::vector<VkSpecializationMapEntry> specMapEntrys(14);
         for (uint32_t i = 0; i < specMapEntrys.size(); i++)
         {
             specMapEntrys[i].constantID = i;
@@ -329,6 +362,30 @@ namespace vkBasalt
                                                &secondBarrier);
         Logger::debug("after the second pipeline barrier");
     }
+
+    void SmaaEffect::useDepthImage(VkImageView depthImageView)
+    {
+        Logger::debug("Using depth image in SMAA");
+
+        for (uint32_t i = 0; i < imageDescriptorSets.size(); ++i) {
+            VkDescriptorImageInfo depthInfo{};
+            depthInfo.sampler = depthSampler;
+            depthInfo.imageView = depthImageView;
+            depthInfo.imageLayout = VK_IMAGE_LAYOUT_SHADER_READ_ONLY_OPTIMAL;
+
+            VkWriteDescriptorSet write{};
+            write.sType = VK_STRUCTURE_TYPE_WRITE_DESCRIPTOR_SET;
+            write.dstSet = imageDescriptorSets[i];
+            write.dstBinding = 5;
+            write.dstArrayElement = 0;
+            write.descriptorType = VK_DESCRIPTOR_TYPE_COMBINED_IMAGE_SAMPLER;
+            write.descriptorCount = 1;
+            write.pImageInfo = &depthInfo;
+
+            pLogicalDevice->vkd.UpdateDescriptorSets(pLogicalDevice->device, 1, &write, 0, nullptr);
+        }
+    }
+
     SmaaEffect::~SmaaEffect()
     {
         Logger::debug("destroying smaa effect " + convertToString(this));

--- a/src/effect_smaa.cpp
+++ b/src/effect_smaa.cpp
@@ -123,7 +123,7 @@ namespace vkBasalt
 
         SmaaOptions smaaOptions;
         smaaOptions.threshold          = pConfig->getOption<float>("smaaThreshold", 0.05f);
-        smaaOptions.depthThreshold     = pConfig->getOption<float>("smaaDepthThreshold", 0.05f);
+        smaaOptions.depthThreshold     = pConfig->getOption<float>("smaaDepthThreshold", 0.01f);
         smaaOptions.maxSearchSteps     = pConfig->getOption<int32_t>("smaaMaxSearchSteps", 32);
         smaaOptions.maxSearchStepsDiag = pConfig->getOption<int32_t>("smaaMaxSearchStepsDiag", 16);
         smaaOptions.cornerRounding     = pConfig->getOption<int32_t>("smaaCornerRounding", 25);

--- a/src/effect_smaa.hpp
+++ b/src/effect_smaa.hpp
@@ -27,6 +27,7 @@ namespace vkBasalt
                    std::vector<VkImage> outputImages,
                    Config*              pConfig);
         void applyEffect(uint32_t imageIndex, VkCommandBuffer commandBuffer) override;
+        void useDepthImage(VkImageView depthImageView) override;
         ~SmaaEffect();
 
     private:
@@ -67,6 +68,7 @@ namespace vkBasalt
         VkDeviceMemory               areaMemory;
         VkDeviceMemory               searchMemory;
         VkSampler                    sampler;
+        VkSampler                    depthSampler;
 
         Config* pConfig;
     };

--- a/src/sampler.cpp
+++ b/src/sampler.cpp
@@ -31,6 +31,35 @@ namespace vkBasalt
         return sampler;
     }
 
+    VkSampler createDepthSampler(LogicalDevice* pLogicalDevice)
+    {
+        VkSampler sampler;
+
+        VkSamplerCreateInfo samplerCreateInfo;
+        samplerCreateInfo.sType                   = VK_STRUCTURE_TYPE_SAMPLER_CREATE_INFO;
+        samplerCreateInfo.pNext                   = nullptr;
+        samplerCreateInfo.flags                   = 0;
+        samplerCreateInfo.magFilter               = VK_FILTER_NEAREST;
+        samplerCreateInfo.minFilter               = VK_FILTER_NEAREST;
+        samplerCreateInfo.mipmapMode              = VK_SAMPLER_MIPMAP_MODE_LINEAR;
+        samplerCreateInfo.addressModeU            = VK_SAMPLER_ADDRESS_MODE_CLAMP_TO_EDGE;
+        samplerCreateInfo.addressModeV            = VK_SAMPLER_ADDRESS_MODE_CLAMP_TO_EDGE;
+        samplerCreateInfo.addressModeW            = VK_SAMPLER_ADDRESS_MODE_CLAMP_TO_EDGE;
+        samplerCreateInfo.mipLodBias              = 0.0f;
+        samplerCreateInfo.anisotropyEnable        = VK_FALSE;
+        samplerCreateInfo.maxAnisotropy           = 16;
+        samplerCreateInfo.compareEnable           = VK_FALSE;
+        samplerCreateInfo.compareOp               = VK_COMPARE_OP_ALWAYS;
+        samplerCreateInfo.minLod                  = 0.0f;
+        samplerCreateInfo.maxLod                  = 0.0f;
+        samplerCreateInfo.borderColor             = VK_BORDER_COLOR_INT_OPAQUE_BLACK;
+        samplerCreateInfo.unnormalizedCoordinates = VK_FALSE;
+
+        VkResult result = pLogicalDevice->vkd.CreateSampler(pLogicalDevice->device, &samplerCreateInfo, nullptr, &sampler);
+        ASSERT_VULKAN(result);
+        return sampler;
+    }
+
     VkSampler createReshadeSampler(LogicalDevice* pLogicalDevice, const reshadefx::sampler_info& samplerInfo)
     {
         VkSampler sampler;

--- a/src/sampler.hpp
+++ b/src/sampler.hpp
@@ -16,6 +16,8 @@ namespace vkBasalt
 {
     VkSampler createSampler(LogicalDevice* pLogicalDevice);
 
+    VkSampler createDepthSampler(LogicalDevice* pLogicalDevice);
+
     VkSampler createReshadeSampler(LogicalDevice* pLogicalDevice, const reshadefx::sampler_info& samplerInfo);
 
     VkSamplerAddressMode convertReshadeAddressMode(const reshadefx::texture_address_mode& addressMode);

--- a/src/shader/meson.build
+++ b/src/shader/meson.build
@@ -9,6 +9,7 @@ shader_src = [
     'smaa_blend.vert.glsl',
     'smaa_edge_color.frag.glsl',
     'smaa_edge_luma.frag.glsl',
+    'smaa_edge_depth.frag.glsl',
     'smaa_edge.vert.glsl',
     'smaa_neighbor.frag.glsl',
     'smaa_neighbor.vert.glsl',

--- a/src/shader/smaa.h
+++ b/src/shader/smaa.h
@@ -50,7 +50,7 @@
  *
  * The shader has three passes, chained together as follows:
  *
- *                           |input|------------------·
+ *                           |input|------------------ï¿½
  *                              v                     |
  *                    [ SMAA*EdgeDetection ]          |
  *                              v                     |
@@ -60,7 +60,7 @@
  *                              v                     |
  *                          |blendTex|                |
  *                              v                     |
- *                [ SMAANeighborhoodBlending ] <------·
+ *                [ SMAANeighborhoodBlending ] <------ï¿½
  *                              v
  *                           |output|
  *
@@ -559,9 +559,11 @@ SamplerState PointSampler { Filter = MIN_MAG_MIP_POINT; AddressU = Clamp; Addres
 #if defined(SMAA_GLSL_3) || defined(SMAA_GLSL_4)
 #define SMAATexture2D(tex) sampler2D tex
 #define SMAATexturePass2D(tex) tex
+#if !defined(SMAASampleLevelZero)
 #define SMAASampleLevelZero(tex, coord) textureLod(tex, coord, 0.0)
 #define SMAASampleLevelZeroPoint(tex, coord) textureLod(tex, coord, 0.0)
 #define SMAASampleLevelZeroOffset(tex, coord, offset) textureLodOffset(tex, coord, 0.0, offset)
+#endif
 #define SMAASample(tex, coord) texture(tex, coord)
 #define SMAASamplePoint(tex, coord) texture(tex, coord)
 #define SMAASampleOffset(tex, coord, offset) texture(tex, coord, offset)
@@ -571,7 +573,9 @@ SamplerState PointSampler { Filter = MIN_MAG_MIP_POINT; AddressU = Clamp; Addres
 #define saturate(a) clamp(a, 0.0, 1.0)
 #if defined(SMAA_GLSL_4)
 #define mad(a, b, c) fma(a, b, c)
+#if !defined(SMAAGather)
 #define SMAAGather(tex, coord) textureGather(tex, coord)
+#endif
 #else
 #define mad(a, b, c) (a * b + c)
 #endif

--- a/src/shader/smaa_edge_depth.frag.glsl
+++ b/src/shader/smaa_edge_depth.frag.glsl
@@ -1,0 +1,31 @@
+#version 450
+#extension GL_GOOGLE_include_directive : require
+
+layout(set = 0, binding = 5) uniform sampler2D depthImg;
+layout(location = 0) out vec4 fragColor;
+layout(location = 0) in vec2 textureCoord;
+layout(location = 1) in vec4[3] offsets;
+
+#include "smaa_settings.h"
+
+#define SMAA_INCLUDE_VS 0
+#define SMAA_INCLUDE_PS 1
+
+// Override SMAA's sampling to use linearized depth
+// Should just multi-pass this really...
+#define SMAASampleLevelZero(tex, coord) vec4(linearizeDepth(tex, coord))
+#define SMAASampleLevelZeroPoint(tex, coord) vec4(linearizeDepth(tex, coord))
+#define SMAASampleLevelZeroOffset(tex, coord, offset) vec4(linearizeDepth(tex, coord + offset * SMAA_RT_METRICS.xy))
+#define SMAAGather(tex, coord) vec4( \
+    linearizeDepth(tex, coord + vec2(0.0, 1.0) * SMAA_RT_METRICS.xy), \
+    linearizeDepth(tex, coord + vec2(1.0, 1.0) * SMAA_RT_METRICS.xy), \
+    linearizeDepth(tex, coord + vec2(1.0, 0.0) * SMAA_RT_METRICS.xy), \
+    linearizeDepth(tex, coord + vec2(0.0, 0.0) * SMAA_RT_METRICS.xy)  \
+)
+
+#include "smaa.h"
+
+void main()
+{
+    fragColor = vec4(SMAADepthEdgeDetectionPS(textureCoord, offsets, depthImg), 0.0, 0.0);
+}

--- a/src/shader/smaa_settings.h
+++ b/src/shader/smaa_settings.h
@@ -1,18 +1,50 @@
-
-
+// SMAA settings
 layout(constant_id = 0) const float screenWidth = 1920;
 layout(constant_id = 1) const float screenHeight = 1080;
 layout(constant_id = 2) const float reverseScreenWidth = 1.0/1920.0;
 layout(constant_id = 3) const float reverseScreenHeight = 1.0/1080.0;
 layout(constant_id = 4) const float threshold = 0.05;
-layout(constant_id = 5) const int   maxSearchSteps = 32;
-layout(constant_id = 6) const int   maxSearchStepsDiag = 16;
-layout(constant_id = 7) const int   cornerRounding = 25;
+layout(constant_id = 5) const float depthThreshold = 0.05;
+layout(constant_id = 6) const int   maxSearchSteps = 32;
+layout(constant_id = 7) const int   maxSearchStepsDiag = 16;
+layout(constant_id = 8) const int   cornerRounding = 25;
+
+// Depth settings
+layout(constant_id = 9) const int      depthInputIsUpsideDown = 0;
+layout(constant_id = 10) const int      depthInputIsReverse = 0;
+layout(constant_id = 11) const int      depthInputIsLogarithmic = 0;
+layout(constant_id = 12) const float    depthMultiplier = 1.0;
+layout(constant_id = 13) const float    depthLinearizationFarPlane = 1000.0;
 
 #define SMAA_RT_METRICS vec4(reverseScreenWidth, reverseScreenHeight, screenWidth, screenHeight)
 #define SMAA_GLSL_4 1
 #define SMAA_THRESHOLD threshold
+#define SMAA_DEPTH_THRESHOLD depthThreshold
 #define SMAA_MAX_SEARCH_STEPS maxSearchSteps
 #define SMAA_MAX_SEARCH_STEPS_DIAG maxSearchStepsDiag
 #define SMAA_CORNER_ROUNDING cornerRounding
 
+// Depth linearization function
+float linearizeDepth(sampler2D depthSampler, vec2 texcoord)
+{
+    vec2 tc = texcoord;
+    if (depthInputIsUpsideDown != 0) {
+        tc.y = 1.0 - tc.y;
+    }
+    
+    float depth = textureLod(depthSampler, tc, 0.0).x * depthMultiplier;
+    
+    if (depthInputIsLogarithmic != 0) {
+        const float C = 0.01;
+        depth = (exp(depth * log(C + 1.0)) - 1.0) / C;
+    }
+    
+    if (depthInputIsReverse != 0) {
+        depth = 1.0 - depth;
+    }
+    
+    const float N = 1.0;
+    depth /= depthLinearizationFarPlane - depth * (depthLinearizationFarPlane - N);
+    
+    return depth;
+}

--- a/src/shader/smaa_settings.h
+++ b/src/shader/smaa_settings.h
@@ -4,7 +4,7 @@ layout(constant_id = 1) const float screenHeight = 1080;
 layout(constant_id = 2) const float reverseScreenWidth = 1.0/1920.0;
 layout(constant_id = 3) const float reverseScreenHeight = 1.0/1080.0;
 layout(constant_id = 4) const float threshold = 0.05;
-layout(constant_id = 5) const float depthThreshold = 0.05;
+layout(constant_id = 5) const float depthThreshold = 0.01;
 layout(constant_id = 6) const int   maxSearchSteps = 32;
 layout(constant_id = 7) const int   maxSearchStepsDiag = 16;
 layout(constant_id = 8) const int   cornerRounding = 25;

--- a/src/shader_sources.hpp
+++ b/src/shader_sources.hpp
@@ -45,6 +45,10 @@ namespace vkBasalt
 #include "smaa_edge_luma.frag.h"
     };
 
+    const std::vector<uint32_t> smaa_edge_depth_frag = {
+#include "smaa_edge_depth.frag.h"
+    };
+
     const std::vector<uint32_t> smaa_edge_vert = {
 #include "smaa_edge.vert.h"
     };


### PR DESCRIPTION
While vkBasalt is not actively updated anymore, I am opening this PR for any other forks who may want to use these patches.

## Summary
This PR adds simple heuristics for capturing the (more likely to be) correct depth image in the swapchain. It does so by comparing the swapchain extent to the size of the depth image, and only capturing the depth image if the two match. In my testing, it works well enough when rendering at native resolution. The depth buffer is always passed to ReShade shaders.

It also adds a third fragment shader for the SMAA edge detection pass, using the depth buffer and SMAA's depth based detection code. The selection is changed from a string to an int, matching ReShade's configuration options.

New configuration options are added for configuring the depth threshold, and the depth buffer linearisation settings.

## Limitations

- Depth capture heuristics are not perfect still, and _will_ miss some cases. There is no user configuration either, it's always on.
- No SMAA predication filtering.
- No separate depth linearisation render pass. This means there is no `gather` support for the depth texture, losing some performance in the process.